### PR TITLE
Added option "DisplayText" which uses the .toString() method on a ret…

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -43,6 +43,8 @@ If you selected SNMP version `v3` you will also need to configure the following:
 You can perform the following actions with this module:
 
 - Get OID value, return to custom variable
+   - Optional update based on connection poll
+   - Optional convert returned OctetString to DisplayString
 - Set OID value to an OctetString
 - Set OID value to a Number. This includes the following SNMP Object Types:
   - Integer

--- a/src/actions.js
+++ b/src/actions.js
@@ -208,13 +208,20 @@ export default async function (self) {
 				tooltip: 'Update each poll interval',
 				default: false,
 			},
+			{
+				type: 'checkbox',
+				label: 'DisplayString',
+				id: 'displaystring',
+				tooltip: 'Convert OctetString (array of numbers) to DisplayString (text)',
+				default: false,
+			},
 		],
 		callback: async ({ options }, context) => {
-			self.getOid(await context.parseVariablesInString(options.oid), options.variable)
+			self.getOid(await context.parseVariablesInString(options.oid), options.variable, options.displaystring)
 		},
 		subscribe: async ({ options }, context) => {
 			if (options.update) {
-				self.getOid(await context.parseVariablesInString(options.oid), options.variable)
+				self.getOid(await context.parseVariablesInString(options.oid), options.variable, options.displaystring)
 			}
 		},
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ class Generic_SNMP extends InstanceBase {
 		})
 	}
 
-	getOid(oid, customVariable) {
+	getOid(oid, customVariable, displaystring) {
 		this.snmpQueue.add(() => {
 			try {
 				this.session.get(
@@ -142,8 +142,13 @@ class Generic_SNMP extends InstanceBase {
 							this.log('warn', `getOid error: ${JSON.stringify(error)} cannot set ${customVariable}`)
 							return
 						}
-						//this.log('debug', `OID: ${varbinds[0].oid} value: ${varbinds[0].value} setting to: ${customVariable}`)
-						this.setCustomVariableValue(customVariable, varbinds[0].value)
+						//this.log('debug', `OID: ${varbinds[0].oid} type: ${varbinds[0].type} value: ${varbinds[0].value} setting to: ${customVariable}`)
+						//this.log('debug', `Repy: ${JSON.stringify(varbinds[0].value)}`)
+						if (displaystring) {
+							this.setCustomVariableValue(customVariable, varbinds[0].value.toString())
+						} else {
+							this.setCustomVariableValue(customVariable, varbinds[0].value)
+						}
 					}).bind(this),
 				)
 			} catch (e) {


### PR DESCRIPTION
#26 
Added option for getOid to convert returned varbind[0].value or string using .toString(). When the return type 4, OctetString, the returned buffer object is converted to an array of ints stored in the custom variable. This change allows the  octetstring array of numbers to be converted to and stored as a text string.

When the returned varbind is displayed in the log the string text shows correctly. Somewhere in the set custom variable chain there may be another way to cause the data to be correctly interpreted as a string so there may be a better Annette or framework standard based way of doing this.

This could also have been done as a separate action, e.g., getOidAsDisplayText, or something similar, but because the underlying functions and structures would be the same with the exception of the tostring call, I’ve felt like it made sense to add it as an option.

It may be better to instead pass a desired return type as the argument to allow, casting or conversion to other data types by sending the desired data type as the argument. The net-snmp library says that input strings are always converted to buffer objects of octetstring type which seems to in use practice map to a c like char array representing a string so default and interpretation as a string maybe appropriate.
