### PR TITLE
v2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generic-snmp",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "src/index.js",
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@companion-module/tools": "^2.3.0",
-    "eslint": "^9.30.0",
+    "eslint": "^9.33.0",
     "prettier": "^3.6.2"
   },
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,13 @@ import * as config from './configs.js'
 import UpdateActions from './actions.js'
 import UpgradeScripts from './upgrades.js'
 
+const trimOid = (oid) => {
+	while (oid.startsWith('.')) {
+		oid = oid.substring(1)
+	}
+	return oid.trim()
+}
+
 class Generic_SNMP extends InstanceBase {
 	constructor(internal) {
 		super(internal)
@@ -125,9 +132,7 @@ class Generic_SNMP extends InstanceBase {
 	}
 
 	async setOid(oid, type, value) {
-		while (oid.startsWith('.')) {
-			oid = oid.substring(1)
-		}
+		oid = trimOid(oid)
 		if (oid.length == 0) return
 		await this.snmpQueue.add(() => {
 			this.session.set([{ oid, type, value }], (error) => {
@@ -145,9 +150,7 @@ class Generic_SNMP extends InstanceBase {
 			const bufferAsHexString = buffer.slice(start, end).toString('hex')
 			return BigInt(`0x${bufferAsHexString}`)
 		}
-		while (oid.startsWith('.')) {
-			oid = oid.substring(1)
-		}
+		oid = trimOid(oid)
 		if (oid.length == 0) return
 		await this.snmpQueue.add(() => {
 			try {
@@ -158,15 +161,15 @@ class Generic_SNMP extends InstanceBase {
 							this.log('warn', `getOid error: ${JSON.stringify(error)} cannot set ${customVariable}`)
 							return
 						}
+						let value
+						if (varbinds[0].type == snmp.ObjectType.Counter64) {
+							value = bufferToBigInt(varbinds[0].value).toString()
+						} else value = displaystring ? varbinds[0].value.toString() : varbinds[0].value
 						if (this.config.verbose)
 							this.log(
 								'debug',
-								`OID: ${varbinds[0].oid} type: ${varbinds[0].type} value: ${varbinds[0].value} setting to: ${customVariable}`,
+								`OID: ${varbinds[0].oid} type: ${snmp.ObjectType[varbinds[0].type]} value: ${value} setting to: ${customVariable}`,
 							)
-						let value = displaystring ? varbinds[0].value.toString() : varbinds[0].value
-						if (varbinds[0].type == snmp.ObjectType.Counter64) {
-							value = bufferToBigInt(varbinds[0].value).toString()
-						}
 						context.setCustomVariableValue(customVariable, value)
 					}).bind(this),
 				)

--- a/src/index.js
+++ b/src/index.js
@@ -164,7 +164,7 @@ class Generic_SNMP extends InstanceBase {
 								`OID: ${varbinds[0].oid} type: ${varbinds[0].type} value: ${varbinds[0].value} setting to: ${customVariable}`,
 							)
 						let value = displaystring ? varbinds[0].value.toString() : varbinds[0].value
-						if (varbinds[0].type == snmp.ObjectType[70]) {
+						if (varbinds[0].type == snmp.ObjectType.Counter64) {
 							value = bufferToBigInt(varbinds[0].value).toString()
 						}
 						context.setCustomVariableValue(customVariable, value)

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,19 +122,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/config-helpers@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@eslint/config-helpers@npm:0.3.0"
-  checksum: 10c0/013ae7b189eeae8b30cc2ee87bc5c9c091a9cd615579003290eb28bebad5d78806a478e74ba10b3fe08ed66975b52af7d2cd4b4b43990376412b14e5664878c8
+"@eslint/config-helpers@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@eslint/config-helpers@npm:0.3.1"
+  checksum: 10c0/f6c5b3a0b76a0d7d84cc93e310c259e6c3e0792ddd0a62c5fc0027796ffae44183432cb74b2c2b1162801ee1b1b34a6beb5d90a151632b4df7349f994146a856
   languageName: node
   linkType: hard
 
-"@eslint/core@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@eslint/core@npm:0.14.0"
+"@eslint/core@npm:^0.15.2":
+  version: 0.15.2
+  resolution: "@eslint/core@npm:0.15.2"
   dependencies:
     "@types/json-schema": "npm:^7.0.15"
-  checksum: 10c0/259f279445834ba2d2cbcc18e9d43202a4011fde22f29d5fb802181d66e0f6f0bd1f6b4b4b46663451f545d35134498231bd5e656e18d9034a457824b92b7741
+  checksum: 10c0/c17a6dc4f5a6006ecb60165cc38bcd21fefb4a10c7a2578a0cfe5813bbd442531a87ed741da5adab5eb678e8e693fda2e2b14555b035355537e32bcec367ea17
   languageName: node
   linkType: hard
 
@@ -155,10 +155,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.30.0":
-  version: 9.30.0
-  resolution: "@eslint/js@npm:9.30.0"
-  checksum: 10c0/aec2df7f4e4e884d693dc27dbf4713c1a48afa327bfadac25ebd0e61a2797ce906f2f2a9be0d7d922acb68ccd68cc88779737811f9769eb4933d1f5e574c469e
+"@eslint/js@npm:9.33.0":
+  version: 9.33.0
+  resolution: "@eslint/js@npm:9.33.0"
+  checksum: 10c0/4c42c9abde76a183b8e47205fd6c3116b058f82f07b6ad4de40de56cdb30a36e9ecd40efbea1b63a84d08c206aadbb0aa39a890197e1ad6455a8e542df98f186
   languageName: node
   linkType: hard
 
@@ -176,13 +176,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/plugin-kit@npm:^0.3.1":
-  version: 0.3.1
-  resolution: "@eslint/plugin-kit@npm:0.3.1"
+"@eslint/plugin-kit@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "@eslint/plugin-kit@npm:0.3.5"
   dependencies:
-    "@eslint/core": "npm:^0.14.0"
+    "@eslint/core": "npm:^0.15.2"
     levn: "npm:^0.4.1"
-  checksum: 10c0/a75f0b5d38430318a551b83e27bee570747eb50beeb76b03f64b0e78c2c27ef3d284cfda3443134df028db3251719bc0850c105f778122f6ad762d5270ec8063
+  checksum: 10c0/c178c1b58c574200c0fd125af3e4bc775daba7ce434ba6d1eeaf9bcb64b2e9fea75efabffb3ed3ab28858e55a016a5efa95f509994ee4341b341199ca630b89e
   languageName: node
   linkType: hard
 
@@ -1052,18 +1052,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.30.0":
-  version: 9.30.0
-  resolution: "eslint@npm:9.30.0"
+"eslint@npm:^9.33.0":
+  version: 9.33.0
+  resolution: "eslint@npm:9.33.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.12.1"
     "@eslint/config-array": "npm:^0.21.0"
-    "@eslint/config-helpers": "npm:^0.3.0"
-    "@eslint/core": "npm:^0.14.0"
+    "@eslint/config-helpers": "npm:^0.3.1"
+    "@eslint/core": "npm:^0.15.2"
     "@eslint/eslintrc": "npm:^3.3.1"
-    "@eslint/js": "npm:9.30.0"
-    "@eslint/plugin-kit": "npm:^0.3.1"
+    "@eslint/js": "npm:9.33.0"
+    "@eslint/plugin-kit": "npm:^0.3.5"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
     "@humanwhocodes/retry": "npm:^0.4.2"
@@ -1098,7 +1098,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/ebc4b17cfd96f308ebaeb12dfab133a551eb03200c80109ecf663fbeb9af83c4eb3c143407c1b04522d23b5f5844fe9a629b00d409adfc460c1aadf5108da86a
+  checksum: 10c0/1e1f60d2b62d9d65553e9af916a8dccf00eeedd982103f35bf58c205803907cb1fda73ef595178d47384ea80d8624a182b63682a6b15d8387e9a5d86904a2a2d
   languageName: node
   linkType: hard
 
@@ -1315,7 +1315,7 @@ __metadata:
   dependencies:
     "@companion-module/base": "npm:~1.12.1"
     "@companion-module/tools": "npm:^2.3.0"
-    eslint: "npm:^9.30.0"
+    eslint: "npm:^9.33.0"
     net-snmp: "npm:^3.23.0"
     p-queue: "npm:^8.1.0"
     prettier: "npm:^3.6.2"


### PR DESCRIPTION
- fix: `Get OID Value` for `Counter64` OID type returns numeric string rather than buffer
- improvement: allow OIDs with leading `.`
- improvement: better logging during `getOid()`