### PR TITLE
v3.1.1

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -49,8 +49,7 @@ If you selected SNMP version `v3` you will also need to configure the following:
 
 You can perform the following actions with this module:
 
-- Get OID value, return to custom variable
-  - Optional update based on connection poll
+- Get OID value, return to custom or local variable
   - `OctetString` and `Opaque` OIDs converted to strings with the encoding option
   - Numeric values may be divided by the `Factor` field to achieved fixed precision decimal values
   - `Counter64` OIDs returned as strings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generic-snmp",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "main": "dist/index.js",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@companion-module/base": "~2.1.1",
-    "es-toolkit": "^1.48.1",
+    "es-toolkit": "^1.49.0",
     "net-snmp": "^3.26.3",
     "p-queue": "^9.3.0"
   },
@@ -27,7 +27,7 @@
     "eslint": "^10.5.0",
     "husky": "^9.1.7",
     "lint-staged": "17.0.8",
-    "prettier": "^3.8.4",
+    "prettier": "^3.8.5",
     "rimraf": "^6.1.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.0",

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -78,7 +78,6 @@ export type ActionSchema = {
 	[ActionId.GetOID]: {
 		options: {
 			oid: string
-			update: boolean
 			div: number
 			encoding: BufferEncoding
 		}
@@ -456,13 +455,6 @@ export default function (self: Generic_SNMP): CompanionActionDefinitions<ActionS
 				choices: self.getOidChoices(),
 				default: self.getOidChoices()[0]?.id ?? '',
 			},
-			{
-				type: 'checkbox',
-				label: 'Update',
-				id: 'update',
-				description: 'Update each poll interval',
-				default: false,
-			},
 			DivisorOption,
 			EncodingOption,
 		],
@@ -479,9 +471,6 @@ export default function (self: Generic_SNMP): CompanionActionDefinitions<ActionS
 		subscribe: async (action, _context) => {
 			const oid = trimOid(action.options.oid)
 			if (!isValidSnmpOid(oid)) throw new Error(`Invalid OID supplied to action: ${action.id}`)
-			if (action.options.update) {
-				self.oidTracker.addToPollGroup(oid, action.id)
-			} else self.oidTracker.removeFromPollGroup(oid, action.id)
 			await self.getOid(oid)
 		},
 		learn: async (action, _context) => {

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -221,6 +221,28 @@ function v310(
 	return upgrade as unknown as CompanionStaticUpgradeResult<ModuleConfig, ModuleSecrets>
 }
 
+function v311(
+	_context: CompanionUpgradeContext<ModuleConfig>,
+	props: CompanionStaticUpgradeProps<ModuleConfig, ModuleSecrets>,
+): CompanionStaticUpgradeResult<ModuleConfig, ModuleSecrets> {
+	const result: CompanionStaticUpgradeResult<ModuleConfig, ModuleSecrets> = {
+		updatedActions: [],
+		updatedConfig: null,
+		updatedSecrets: null,
+		updatedFeedbacks: [],
+	}
+
+	for (const action of props.actions) {
+		if (action.actionId === (ActionId.GetOID as string)) {
+			if ('update' in action.options) {
+				delete action.options.update
+				result.updatedActions.push(action)
+			}
+		}
+	}
+	return result
+}
+
 export const UpgradeScripts: CompanionStaticUpgradeScript<ModuleConfig, ModuleSecrets>[] = [
 	pre200,
 	v210,
@@ -228,4 +250,5 @@ export const UpgradeScripts: CompanionStaticUpgradeScript<ModuleConfig, ModuleSe
 	v230,
 	v300,
 	v310,
+	v311,
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,9 +1112,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-toolkit@npm:^1.48.1":
-  version: 1.48.1
-  resolution: "es-toolkit@npm:1.48.1"
+"es-toolkit@npm:^1.49.0":
+  version: 1.49.0
+  resolution: "es-toolkit@npm:1.49.0"
   dependenciesMeta:
     "@trivago/prettier-plugin-sort-imports@4.3.0":
       unplugged: true
@@ -1122,7 +1122,7 @@ __metadata:
       unplugged: true
     vitepress-plugin-sandpack@1.1.4:
       unplugged: true
-  checksum: 10c0/29bfccb8aaf088f27ea91b5bf6448b8a46ef5d809139ad9335bea6919d0bc3aadc3206c957ab6c72d65864906fd75cf9ab41fbd936aaf69e58c6259d2821187d
+  checksum: 10c0/ab0864bb0c5c494ed09043d53a74b58a0ab9df1b89b9b54bce72a63de2869152d7d65e489dc89ab671f0fea243728922c8a8f8c873f1b2a53350a23360b3e2df
   languageName: node
   linkType: hard
 
@@ -1568,13 +1568,13 @@ __metadata:
     "@companion-module/tools": "npm:^3.0.2"
     "@types/net-snmp": "npm:^3.23.0"
     "@types/node": "npm:^26.0.1"
-    es-toolkit: "npm:^1.48.1"
+    es-toolkit: "npm:^1.49.0"
     eslint: "npm:^10.5.0"
     husky: "npm:^9.1.7"
     lint-staged: "npm:17.0.8"
     net-snmp: "npm:^3.26.3"
     p-queue: "npm:^9.3.0"
-    prettier: "npm:^3.8.4"
+    prettier: "npm:^3.8.5"
     rimraf: "npm:^6.1.3"
     typescript: "npm:^6.0.3"
     typescript-eslint: "npm:^8.62.0"
@@ -2349,12 +2349,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.8.4":
-  version: 3.8.4
-  resolution: "prettier@npm:3.8.4"
+"prettier@npm:^3.8.5":
+  version: 3.8.5
+  resolution: "prettier@npm:3.8.5"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/b90a0cbe75b88ac0af9c13fe0f359bd19926fabccd88483227b21f71f0c1cc42da056fc1ac3a361e665577c568371d5ccfb2c62c31c8a1186f8d1bd531a063e9
+  checksum: 10c0/57ba3cd8ddc0cebcb31038f09081da5c8633ff1823ff5e5cf3496918b3b839f76a21e06050fd1a2c41547f44fedea2c28d7a4a26f0b2ed40eb60428c54c297ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Fix: Remove `update` option from `getOID` action. Broken since `v3.0.0` and incompatible with new module architecture. Resolves #64 
- Chore: Update `es-toolkit`, `prettier`